### PR TITLE
MAC Address Spoofer - by Abhinandan Khurana

### DIFF
--- a/MAC Address Spoofer/README.md
+++ b/MAC Address Spoofer/README.md
@@ -1,0 +1,30 @@
+# MAC Address Spoofer
+
+<pre style="color:green">
+   _____      _____  _________      _____       .___  .___                                _________                     _____             
+  /     \    /  _  \ \_   ___ \    /  _  \    __| _/__| _/______   ____   ______ ______  /   _____/_____   ____   _____/ ____\___________ 
+ /  \ /  \  /  /_\  \/    \  \/   /  /_\  \  / __ |/ __ |\_  __ \_/ __ \ /  ___//  ___/  \_____  \\____ \ /  _ \ /  _ \   __\/ __ \_  __ \
+/    Y    \/    |    \     \____ /    |    \/ /_/ / /_/ | |  | \/\  ___/ \___ \ \___ \   /        \  |_> >  <_> |  <_> )  | \  ___/|  | \/
+\____|__  /\____|__  /\______  / \____|__  /\____ \____ | |__|    \___  >____  >____  > /_______  /   __/ \____/ \____/|__|  \___  >__|   
+        \/         \/        \/          \/      \/    \/             \/     \/     \/          \/|__|                           \/       
+ 
+ ~ by Abhinandan Khurana
+ </pre>                                                                                                                                         
+                                                                              
+
+
+This is a Python based command line MAC Address Spoofer utility for LINUX systems, which takes input as an argument for the exact interface you wish to modify the MAC Address for and changes the MAC Address.
+
+
+
+##  How to use?
+
+<pre>
+sudo python mac_changer.py --help   --> for help menu
+
+sudo python mac_changer.py -i [INTERFACE] -m [NEW_MAC]
+
+eg., sudo python mac_changer.py -i eth0 -m 00:11:22:33:44:55
+</pre>
+
+__________________________________________________________________________________________________________________________________________________________________________________

--- a/MAC Address Spoofer/mac_address_spoofer.py
+++ b/MAC Address Spoofer/mac_address_spoofer.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+
+import subprocess
+import optparse
+import re
+
+
+def arguments_func():
+	parser = optparse.OptionParser()
+	parser.add_option("-i","--interface",dest="interface",help="Interface to change its MAC address")
+	parser.add_option("-m","--mac",dest="new_mac",help="New MAC address")
+	(options, arguments) = parser.parse_args()
+	if not options.interface:
+		parser.error("\033[1;31m [-] Please specify an interface, use --help for more info")
+	elif not options.new_mac:
+		parser.error("\033[1;31m [-] Please specify a new MAC address, use --help for more info")
+	else:
+		return options
+
+def mac_changer(interface, new_mac):
+	print("\033[1;33m [+] Changing MAC address for " + interface + " to " + new_mac)
+	subprocess.call(["ifconfig", interface, "down"])
+	subprocess.call(["ifconfig",interface,"hw","ether",new_mac])
+	subprocess.call(["ifconfig",interface,"up"])
+
+
+def get_current_mac(interface):
+	ifconfig_result = subprocess.check_output(["ifconfig", interface])
+	mac_search_result = re.search(r"\w\w:\w\w:\w\w:\w\w:\w\w:\w\w", ifconfig_result)
+
+	if mac_search_result:
+		return mac_search_result.group(0)
+	else:
+		print("\033[1;31m [-] Could not read MAC address")
+
+
+
+(options) = arguments_func()
+current_mac = get_current_mac(options.interface)
+print("\033[1;34m Your current MAC address is: " + str(current_mac))
+mac_changer(options.interface, options.new_mac)
+current_mac = get_current_mac(options.interface)
+if current_mac == options.new_mac:
+	print("\033[1;32m MAC address was successfully changed to " + current_mac)
+else:
+	print("\033[1;31m [x] MAC address did not get changed")


### PR DESCRIPTION
This is a Python based command line MAC Address Spoofer utility for LINUX systems, which takes input as an argument for the exact interface you wish to modify the MAC Address for and changes the MAC Address.