### PR TITLE
Add terraform script to create RDS instance and DB inside a VPC

### DIFF
--- a/Terraform-scripts-AWS/rds/rds.tf
+++ b/Terraform-scripts-AWS/rds/rds.tf
@@ -1,0 +1,31 @@
+resource "aws_db_instance" "default" {
+  allocated_storage    = 10
+  db_name              = "mydb"
+  engine               = "mysql"
+  engine_version       = "5.7"
+  instance_class       = "db.t3.micro"
+  username             = "foo"
+  password             = "foobarbaz"
+  parameter_group_name = "default.mysql5.7"
+  skip_final_snapshot  = true
+  db_subnet_group_name = aws_db_subnet_group.subnet_group.name
+}
+
+resource "aws_vpc" "vpc" {
+  cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_subnet" "subnet_region_1" {
+  vpc_id     = aws_vpc.vpc.id
+  cidr_block = "10.0.1.0/24"
+}
+
+resource "aws_subnet" "subnet_region_2" {
+  vpc_id     = aws_vpc.vpc.id
+  cidr_block = "10.0.1.0/16"
+}
+
+resource "aws_db_subnet_group" "subnet_group" {
+  name       = "main"
+  subnet_ids = [aws_subnet.subnet_region_1.id, aws_subnet.subnet_region_2.id]
+}


### PR DESCRIPTION
Created a terraform script which will create a separate virtual network and have the database inside the private subnets so that the DB will not be exposed to the outside world